### PR TITLE
Update to gpt-3.5-turbo-instruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This web application uses OpenAI's GPT-3 language model to convert a blog post o
 - Frontend: React & CSS.
 - Backend serverless function: NextJS.
 - Utilises OpenAI API.
-- text-davinci-003 model.
+- gpt-3.5-turbo-instruct model.
 - Base prompt created following experimentation using OpenAI playground.
 - Temperature and max tokens optimised following experimentation in playground.
 - Continuous deployment to Railway directly from GitHub.

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -21,7 +21,7 @@ const generateAction = async (req, res) => {
 
   try {
     const baseCompletion = await openai.createCompletion({
-      model: "text-davinci-003",
+      model: "gpt-3.5-turbo-instruct",
       prompt: `${basePromptPrefix}${req.body.userInput}\n`,
       temperature: 0.7,
       max_tokens: 1000,


### PR DESCRIPTION
## Summary
- switch OpenAI model to `gpt-3.5-turbo-instruct`
- update docs to mention the newer model

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6858310bc0cc832c9013b50574fe910e