### PR TITLE
Add input length validation

### DIFF
--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -14,6 +14,12 @@ Blog post:
 const generateAction = async (req, res) => {
   console.log(`API: ${basePromptPrefix}${req.body.userInput}`);
 
+  if (req.body.userInput && req.body.userInput.length > 2000) {
+    return res
+      .status(400)
+      .json({ error: "User input exceeds 2000 character limit" });
+  }
+
   if (!process.env.OPENAI_API_KEY) {
     console.error("Missing OpenAI API Key");
     return res.status(500).json({ error: "OpenAI request failed" });


### PR DESCRIPTION
## Summary
- validate `req.body.userInput` in the API route
- reject requests over 2000 characters

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583a653370832c9d34a20c289b0833